### PR TITLE
[Python] 라인별 최장 길이 글자 수 변경

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -4,7 +4,7 @@ Python
 파이썬의 코드 스타일은 기본적으로 [PEP8](https://www.python.org/dev/peps/pep-0008/) 에서 제안하는 방식을 지향합니다.
 
 ## Maximum Line Length
-라인별 최고 길이는 79자를 넘지 않도록 합니다.
+라인별 최장 길이는 120자를 넘지 않도록 합니다.
 
 ## Line Break with Binary Operator
 이항 연산자를 사용할 때 연산자 이전에 줄바꿈을 한다.


### PR DESCRIPTION
현재 실제 사용되고 있는 기준에 따라 79자 -> 120자로 변경합니다.

추가로, PEP8에서는 기본으로 79자로 제안하고 팀에 따라서 99자까지 늘리는 걸 허용하고 있는데
(무조건 PEP8을 지켜야 한다는 의미는 아닙니다!)
120자로 정해진 배경도 궁금합니다.