### PR TITLE
[Python] 타입 힌트 내용 보완

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -53,24 +53,18 @@ def greeting(name):
 
 #### Do
 ```python
+import typing_extensions import Self
+
 class Car:
     def move(self, goal: str) -> str:
         return "Move to " + goal
 
+    def follow(self, other: Self) -> str:
+        return "Follow"
+
+    @classmethod
     def get_name(cls) -> str:
         return "My Car"
-```
-
-return을 통해 값을 반환하지 않는 함수는 반환형 타입 힌트를 생략할 수 있습니다.
-
-#### Do
-```python
-def show_movie(name: str):
-    print("Hello " + name)
-
-
-def show_movie(name: str) -> None:
-    print("Hello " + name)
 ```
 
 


### PR DESCRIPTION
#59 의 리뷰를 반영합니다.

* 누락된 데코레이터 `@classmethod` 추가
* Self 사용에 대한 구체적인 예시 추가
* return을 통해 값을 반환하지 않는 함수 내용 제거