### PR TITLE
[Python] 타입 힌트 내용 보완 - None 타입

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -67,7 +67,7 @@ class Car:
         return "My Car"
 ```
 
-return을 통해 값을 반환하지 않는 함수에는 반환형 타입 힌트으로 None을 적습니다.
+return을 통해 값을 반환하지 않는 함수에서도 반환형을 명시합니다(`None`).
 
 #### Do
 ```python

--- a/Python/README.md
+++ b/Python/README.md
@@ -67,6 +67,20 @@ class Car:
         return "My Car"
 ```
 
+return을 통해 값을 반환하지 않는 함수에는 반환형 타입 힌트으로 None을 적습니다.
+
+#### Do
+```python
+def show_movie(name: str) -> None:
+    print("Hello " + name)
+
+
+def show_movie(name: str) -> None:
+    if not name:
+        return
+    print("Hello " + name)
+```
+
 
 ## 이외의 규칙
 


### PR DESCRIPTION
#60 의 [리뷰](https://github.com/8percent/styleguide/pull/59#discussion_r1298038505)를 반영합니다.

함수의 반환 값이 None인 경우는 세 가지 있습니다.
```python
# Case 1
def foo():
    return None

# Case 2
def boo():
    return

# Case 3
def voo():
    pass
```
첫 번째 경우는 로직 측면에서 지양해야 합니다.
두 번째 경우와 세 번째 경우에 대해 반환형 타입 힌트로 None을 적습니다.